### PR TITLE
PD2Hook no longer required.

### DIFF
--- a/lib/Lua/poco.lua
+++ b/lib/Lua/poco.lua
@@ -1,0 +1,11 @@
+--RegisterScript("poco/common.luac", 1, "UNDERSCORE")
+--RegisterScript("poco/common.luac", 1, "PocoHud3")
+if not GetPersistScript("UNDERSCORE") then AddPersistScript("UNDERSCORE", "poco/common.luac") end
+if not GetPersistScript("PocoHud3") then AddPersistScript("PocoHud3", "poco/Hud3.luac") end
+
+--[[
+Commented lines are how it is supposed to work as documented, however both keybind and persist modes seem to
+not currently function when using RegisterScript, while post-requires do work. As a workaround the two
+uncommented lines are in use, which provide identical functionality for minimal (possibly no) additional
+overhead.
+--]]


### PR DESCRIPTION
I went ahead and created the PD2Hook.yml workaround for you. It was slightly more difficult than expect due to RegisterScript not functioning as documented, however the workaround was easy to find using other pre-existing functions. It requires version 3.2.0 of the LUA hook, so be sure it uses that.