### PR TITLE
Add detection risk indicator at Bottom Infobox

### DIFF
--- a/Hud3.lua
+++ b/Hud3.lua
@@ -921,6 +921,20 @@ function TPocoHud3:_updatePlayers(t)
 			if not btmO.underneath then
 				txts[#txts+1]={'\n'}
 			end
+			if _show('DetectionRisk') then
+				local suspicion
+				if isMe then
+					suspicion = managers.blackmarket:get_suspicion_offset_of_local(75)
+				else
+					local member = self:_member(i)
+					if member and alive(member:unit()) then
+						suspicion = managers.blackmarket:get_suspicion_offset_of_peer(member:peer(), 75)
+					end
+				end
+				if suspicion then
+					txts[#txts+1]={' '..Icon.Ghost..string.format("%.0f%%", suspicion),cl.CornFlowerBlue}
+				end
+			end
 			if _show('Kill') then
 				txts[#txts+1]={' '..Icon.Skull..kill,color}
 			end

--- a/Hud3_Options.lua
+++ b/Hud3_Options.lua
@@ -93,6 +93,7 @@ local scheme = {
 		showPing = {'num',2,{0,2},'_opt_showPing_desc','Verbose'},
 		showConvertedEnemy = {'num',1,{0,2},'_opt_showConvertedEnemy_desc','Verbose'},
 		showArrow = {'bool',TRUE,nil,'_opt_showArrow_desc'},
+		showDetectionRisk = {'num',1,{0,2},'_opt_showDetectionRisk_desc','Verbose'},
 	}, popup = {	'_opt_popup_desc',
 		enable = {'bool',TRUE,nil,'_opt_enable_desc'},
 		size  = {'num',22,{10,30},'_opt_size_desc',nil,nil,1},

--- a/hud3_localeEN.json
+++ b/hud3_localeEN.json
@@ -281,6 +281,8 @@
     "_opt_showConvertedEnemy": "SHOW CONVERTED ENEMY",
     "_opt_showConvertedEnemy_desc": "Minion health as percent if one has any",
     "_opt_showConvertedEnemy_desc2": "Try to color-code them to the master.",
+    "_opt_showDetectionRisk": "SHOW DETECTION RISK",
+    "_opt_showDetectionRisk_desc": "Show Detection Risk Percentage (e.g 3%-75%)",
     "_opt_showDistance": "SHOW DISTANCE",
     "_opt_showDistance_desc": "e.g) 25m",
     "_opt_showDowns": "SHOW DOWNS",


### PR DESCRIPTION
Hi, thank you for the nice mod.
I wanted to check the detection risk percentage in-game and added a blue number at left of the kill counter.

![example](https://cloud.githubusercontent.com/assets/25494/7456266/3a11a37e-f2be-11e4-8103-857c3627d9b4.jpg)

It's a bit confusing to use already present ghost icon, but I couldn't come up with good alternative.

* Modified TPocoHud3:_updatePlayers to show the indicator in the bottom.
* Added playerBottom.showDetectionRisk option (defaults to Detailed Mode Only).
* Added localisation labels: _opt_showDetectionRisk and _opt_showDetectionRisk_desc.