### PR TITLE
Fix for negative numbers in _.F (formatting function)

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -27,7 +27,8 @@ _ = {
 	F = function (n,k) -- ff
 		k = k or 2
 		if type(n) == 'number' then
-			local r = string.format('%.'..k..'g', n):sub(1,k+2)
+			n = (n > 0 and math.floor(n * 100) or math.ceil(n * 100)) / 100
+			local r = string.format('%.'..k..'g', n)
 			return r:find('e') and tostring(math.floor(n)) or r
 		elseif type(n) == 'table' then
 			return _.i(n):gsub('\n','')


### PR DESCRIPTION
Formatting of negative numbers in _.F() is partially broken: Low-value numbers such as -130 are being formatted wrong, in this example, F(-130.0) returns "-1.3" instead of "-130".
This change fixes the negative numbers' formatting, and from the testing I have done, seems to keep the other formats for buff and interaction timers pretty much how they were before.