### PR TITLE
TriggerHappy buff hotfix update 100

### DIFF
--- a/Hud3.lua
+++ b/Hud3.lua
@@ -1553,7 +1553,7 @@ function TPocoHud3:_hook()
 				if managers.player:has_category_upgrade(weapon_category, "stacking_hit_damage_multiplier") then
 					local stack = self._state_data and self._state_data.stacking_dmg_mul and self._state_data.stacking_dmg_mul[weapon_category]
 					if stack and stack[1] and t < stack[1] then
-						local mul = 1 + managers.player:upgrade_value(weapon_category, "stacking_hit_damage_multiplier") * stack[2]
+						local mul = 1 + ((managers.player:upgrade_value(weapon_category, "stacking_hit_damage_multiplier").damage_bonus - 1) * stack[2])
 						me:Buff({
 							key='triggerHappy', good=true,
 							icon=skillIcon, iconRect = {7*64, 11*64, 64, 64},


### PR DESCRIPTION
Fixes: https://github.com/zenyr/PocoHud3/issues/37

managers.player:upgrade_value(weapon_category, "stacking_hit_damage_multiplier") now contains a lua table looking like:
```lua
stacking_hit_damage_multiplier = {max_stacks = 4,
max_time = 10,
damage_bonus = 1.2000000476837,
}
```

This is the root cause for the crashes that have been happening after update 100. The correct behaviour in order to display the multiplier would be:
1 + (damanager_bonus - 1) * stack.

This now causes the game to not crash when trigger_happy is used after update 100. 

Consider this a hotfix. The buff seems to dissapear quite quickly but at least the game does not crash. I'll continue looking for why the buff dissapears so quickly. 