### PR TITLE
Changed damage values if string to number. Fixes a crash.

### DIFF
--- a/Hud3.lua
+++ b/Hud3.lua
@@ -151,6 +151,8 @@ function TPocoHud3:AddDmgPopByUnit(sender,unit,offset,damage,death,head,dmgType)
 end
 local _lastAttk, _lastAttkpid = 0,0
 function TPocoHud3:AddDmgPop(sender,hitPos,unit,offset,damage,death,head,dmgType)
+	if type(damage) == 'string' then damage = tonumber(damage) end
+	
 	local Opt = O:get('popup')
 	if self.dead then return end
 	local pid = self:_pid(sender)


### PR DESCRIPTION
Crash occured during DOT (like fire) value pop-ups.

Related Steam community thread: http://steamcommunity.com/app/218620/discussions/15/154641879464910946/